### PR TITLE
fix: Change NIM validation refresh rate from 24h to 1h to align with NGC API key constraints

### DIFF
--- a/api/nim/v1/account_types.go
+++ b/api/nim/v1/account_types.go
@@ -13,9 +13,9 @@ type AccountSpec struct {
 	APIKeySecret corev1.ObjectReference `json:"apiKeySecret"`
 	// A reference to the ConfigMap containing the list of NIM models that are allowed to be deployed.
 	ModelListConfig *corev1.ObjectReference `json:"modelListConfig,omitempty"`
-	// Refresh Rate for validation, defaults to 24h
+	// Refresh Rate for validation, defaults to 1h
 	// +kubebuilder:validation:Format="duration"
-	// +kubebuilder:default:="24h"
+	// +kubebuilder:default:="1h"
 	// +kubebuilder:validation:Optional
 	ValidationRefreshRate string `json:"validationRefreshRate"`
 	// Refresh rate for models data, defaults to 24h

--- a/internal/controller/constants/constants.go
+++ b/internal/controller/constants/constants.go
@@ -124,7 +124,7 @@ const (
 // NIM
 const (
 	NimApplyConfigFieldManager   = "nim-account-controller"
-	NimValidationRefreshRate     = time.Hour * 24
+	NimValidationRefreshRate     = time.Hour * 1
 	NimConfigRefreshRate         = time.Hour * 24
 	NimCleanupFinalizer          = "runtimes.opendatahub.io/nim-cleanup-finalizer"
 	NimForceValidationAnnotation = "runtimes.opendatahub.io/nim-force-validation"


### PR DESCRIPTION
This PR fixes the NGC API key validation refresh rate issue where expired API keys showed as healthy for up to 23 hours.

## Problem
The NIM controller was only validating NGC API keys once every 24 hours, but NGC API keys have a minimum expiration time of 1 hour. This created a 23-hour window where API keys appeared healthy but deployments failed.

## Solution
Changed the validation refresh rate from 24 hours to 1 hour to align with NGC's minimum API key expiration time.

## Changes Made
- Changed NimValidationRefreshRate constant from 24 hours to 1 hour
- Updated kubebuilder default annotation from '24h' to '1h'

## Related Issues
- Fixes: NVPE-350